### PR TITLE
Removed  Spamcannibal because it is no longer active list

### DIFF
--- a/blacklists.go
+++ b/blacklists.go
@@ -3,7 +3,6 @@ package main
 var BlacklistEntries []string = []string{
 	"access.redhawk.org",
 	"b.barracudacentral.org",
-	"bl.spamcannibal.org",
 	"bl.spamcop.net",
 	"blackholes.mail-abuse.org",
 	"bogons.cymru.com",


### PR DESCRIPTION
I have removed list bl.spamcannibal.org because it is no longer an active list.